### PR TITLE
Fix for failing builds using Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
       env: DJANGO_VERSION=1.11
 before_install:
     - export DJANGO_SETTINGS_MODULE="podcast.tests.settings"
+    - if [ $TRAVIS_PYTHON_VERSION = 3.3 ] && [ $DJANGO_VERSION = 1.8.18 ]; then pip uninstall --yes setuptools; pip install setuptools; fi
 install:
     - pip install -q Django==$DJANGO_VERSION
     - python setup.py -q install


### PR DESCRIPTION
I did some experimentation and made lots of syntax errors, but this should be a fix for the failing builds issue- it looks like the setup tools version was incorrect, so we wrote a small bash if statement to uninstall the incorrect version and install the correct version.