### PR TITLE
Feed media url must not be redirect

### DIFF
--- a/podcast/feeds.py
+++ b/podcast/feeds.py
@@ -167,9 +167,12 @@ class ShowFeed(Feed):
         return item.pub_date
 
     def item_enclosure_url(self, item):
+        try:
+            enclosure = Enclosure.objects.get(episode=item)
+        except Enclosure.DoesNotExist:
+            return None
         current_site = get_current_site(self.request)
-        enclosure_url = item.get_absolute_download_url()
-        return add_domain(current_site.domain, enclosure_url, self.request.is_secure())
+        return add_domain(current_site.domain, enclosure.file.url, self.request.is_secure())
 
     def item_enclosure_length(self, item):
         try:


### PR DESCRIPTION
Hi, so we recently received an email from Apple stating that they'd removed our podcast episodes from iTunes due to the media file urls being redirects - they want the file straight.

>I have reached out to our operations team and they have informed the issue is with your feed. We are not able to read the media files in your feed because the media links redirect to other resources as shown below.

>Please update your feed to have the direct links to the media files in the RS Feed, not as a redirect.

So here is what they wanted.

Thanks.